### PR TITLE
Fix edit link in msf6 post

### DIFF
--- a/msf6.md
+++ b/msf6.md
@@ -11,7 +11,7 @@ ShowToc: true
 TocOpen: false
 searchHidden: false
 editPost:
-  URL: "https://github.com/Marcin13/posts/blob/master/Nmap.md"
+  URL: "https://github.com/Marcin13/posts/blob/master/msf6.md"
 ---
 
 Using Metasploit to scan a target for vulnerabilities:


### PR DESCRIPTION
## Summary
- fix `msf6.md` frontmatter to point the edit link at `msf6.md`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6849bee80c508326a9dcb273d30d6e58